### PR TITLE
feat(web-dapp): update airdrop ui state based contracts information.

### DIFF
--- a/modules/web-dapp/.eslintrc.js
+++ b/modules/web-dapp/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
     "import/prefer-default-export": "off",
     "import/no-default-export": "error",
     "react/prop-types": "off",
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
     "import/extensions": [
       "error",
       "ignorePackages",

--- a/modules/web-dapp/src/App.tsx
+++ b/modules/web-dapp/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import "./App.css";
-import { CssBaseline, ThemeProvider } from "@mui/material";
+import { ThemeProvider } from "@mui/material";
 import { ClaimPage } from "./page/ClaimPage";
 import { theme } from "./config/theme";
 import { Home } from "./page/Home";
@@ -20,7 +20,6 @@ const styles = {
 export const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
-      <CssBaseline />
       <div style={styles.background}>
         <Router>
           <Header />

--- a/modules/web-dapp/src/config/constants.ts
+++ b/modules/web-dapp/src/config/constants.ts
@@ -2,6 +2,13 @@
 const DefaultLocalGreeterContractAddress =
   "0x5FbDB2315678afecb367f032d93F642f64180aa3";
 
+const DefaultLocalAirdropContractAddress =
+  "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0";
+
 export const GreeterContractAddress =
   process.env.REACT_APP_GREETER_CONTRACT_ADDRESS ||
   DefaultLocalGreeterContractAddress;
+
+export const AirdropContractAddress =
+  process.env.REACT_APP_AIRDROP_CONTRACT_ADDRESS ||
+  DefaultLocalAirdropContractAddress;

--- a/modules/web-dapp/src/helpers/formatters.js
+++ b/modules/web-dapp/src/helpers/formatters.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 export const n6 = new Intl.NumberFormat("en-us", {
   style: "decimal",
   minimumFractionDigits: 0,

--- a/modules/web-dapp/src/hooks/useAirdropContract.ts
+++ b/modules/web-dapp/src/hooks/useAirdropContract.ts
@@ -7,6 +7,7 @@ interface UseAirdropContract {
   error?: string;
   isWhitelisted?: boolean;
   isClaimed?: boolean;
+  amountToBeClaimed?: number;
 }
 
 /**
@@ -17,8 +18,11 @@ interface UseAirdropContract {
  */
 export const useAirdropContract = (): UseAirdropContract => {
   const { library, account } = useWeb3React();
-  const [isWhitelisted, setIsWhitelisted] = useState();
-  const [isClaimed, setIsClaimed] = useState();
+  const [isWhitelisted, setIsWhitelisted] = useState<boolean | undefined>();
+  const [isClaimed, setIsClaimed] = useState<boolean | undefined>();
+  const [amountToBeClaimed, setAmountToBeClaimed] = useState<
+    number | undefined
+  >();
   const [error, setError] = useState<string | undefined>();
 
   // useMemo to ensure we only initialize Contract once
@@ -42,9 +46,14 @@ export const useAirdropContract = (): UseAirdropContract => {
       return;
     }
 
-    airdropContract
-      .claims(account)
-      .then((claimed) => setIsClaimed(claimed))
+    Promise.all([
+      airdropContract.claims(account),
+      airdropContract.amountToBeClaimed(),
+    ])
+      .then(([claimed, amount]) => {
+        setIsClaimed(claimed);
+        setAmountToBeClaimed(amount);
+      })
       .catch((err) => setError(`Error checking claimed status: ${err}`));
   }, [isWhitelisted]);
 
@@ -52,5 +61,6 @@ export const useAirdropContract = (): UseAirdropContract => {
     error,
     isWhitelisted,
     isClaimed,
+    amountToBeClaimed,
   };
 };

--- a/modules/web-dapp/src/hooks/useAirdropContract.ts
+++ b/modules/web-dapp/src/hooks/useAirdropContract.ts
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useState } from "react";
+import { AirDrop__factory as AirdropFactory } from "@homiesglobal/contracts";
+import { useWeb3React } from "@web3-react/core";
+import { AirdropContractAddress } from "../config/constants";
+
+interface UseAirdropContract {
+  error?: string;
+  isWhitelisted?: boolean;
+  isClaimed?: boolean;
+}
+
+/**
+ * useAirdropContract is a react hook that make it easy to interact with the
+ * HOMIE Airdrop Contract.
+ * NOTE: Only use this hook after confirming the users wallet is connected
+ * because this doesn't do any checks
+ */
+export const useAirdropContract = (): UseAirdropContract => {
+  const { library, account } = useWeb3React();
+  const [isWhitelisted, setIsWhitelisted] = useState();
+  const [isClaimed, setIsClaimed] = useState();
+  const [error, setError] = useState<string | undefined>();
+
+  // useMemo to ensure we only initialize Contract once
+  const airdropContract = useMemo(() => {
+    return AirdropFactory.connect(AirdropContractAddress, library);
+  }, [library]);
+
+  // try fetching if address is whitelisted
+  useEffect(() => {
+    airdropContract
+      .allowed(account)
+      .then((isAllowed) => {
+        setIsWhitelisted(isAllowed);
+      })
+      .catch((err) => setError(`Error checking whitelist status: ${err}`));
+  }, []);
+
+  // try fetching if claimed/not only if whitelisted
+  useEffect(() => {
+    if (!isWhitelisted) {
+      return;
+    }
+
+    airdropContract
+      .claims(account)
+      .then((claimed) => setIsClaimed(claimed))
+      .catch((err) => setError(`Error checking claimed status: ${err}`));
+  }, [isWhitelisted]);
+
+  return {
+    error,
+    isWhitelisted,
+    isClaimed,
+  };
+};

--- a/modules/web-dapp/src/hooks/useClaimPage.ts
+++ b/modules/web-dapp/src/hooks/useClaimPage.ts
@@ -10,6 +10,9 @@ export enum ClaimPageState {
 
 interface UseClaimPage {
   currentState: ClaimPageState;
+  amountToBeClaimed?: number;
+  tokenSymbol?: string;
+  tokenDecimals?: number;
   error?: string;
 }
 
@@ -37,5 +40,8 @@ export const useClaimPage = (): UseClaimPage => {
   return {
     currentState,
     error: airdrop.error,
+    amountToBeClaimed: airdrop.amountToBeClaimed,
+    tokenSymbol: "HOMIE", // hardcoding this, but ideally should be fetched from contract
+    tokenDecimals: 2, // same with this
   };
 };

--- a/modules/web-dapp/src/hooks/useClaimPage.ts
+++ b/modules/web-dapp/src/hooks/useClaimPage.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { useAirdropContract } from "./useAirdropContract";
+
+export enum ClaimPageState {
+  LoadingState,
+  NotEligibleState,
+  EligibleState,
+  TokenClaimedState,
+}
+
+interface UseClaimPage {
+  currentState: ClaimPageState;
+  error?: string;
+}
+
+export const useClaimPage = (): UseClaimPage => {
+  const [currentState, setCurrentState] = useState<ClaimPageState>(
+    ClaimPageState.LoadingState
+  );
+  const airdrop = useAirdropContract();
+
+  useEffect(() => {
+    if (airdrop.isWhitelisted !== undefined && !airdrop.isWhitelisted) {
+      setCurrentState(ClaimPageState.NotEligibleState);
+      return;
+    }
+
+    if (airdrop.isClaimed !== undefined) {
+      if (airdrop.isClaimed) {
+        setCurrentState(ClaimPageState.TokenClaimedState);
+      } else {
+        setCurrentState(ClaimPageState.EligibleState);
+      }
+    }
+  }, [airdrop]);
+
+  return {
+    currentState,
+    error: airdrop.error,
+  };
+};

--- a/modules/web-dapp/src/index.css
+++ b/modules/web-dapp/src/index.css
@@ -37,6 +37,7 @@ body {
   line-height: 1.5;
   background-color: white;
   font-family: "Open Sans";
+  font-size: 1.5rem;
 }
 
 ul[class],

--- a/modules/web-dapp/src/index.js
+++ b/modules/web-dapp/src/index.js
@@ -27,7 +27,7 @@ const Application = () => {
 
 ReactDOM.render(
   <StrictMode>
-    <Application />,
+    <Application />
   </StrictMode>,
   document.getElementById("root")
 );

--- a/modules/web-dapp/src/page/ClaimPage.tsx
+++ b/modules/web-dapp/src/page/ClaimPage.tsx
@@ -1,5 +1,12 @@
-import { Button, Grid, styled, Typography } from "@mui/material";
-import React from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Grid,
+  styled,
+  Typography,
+} from "@mui/material";
+import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import { AppRoute } from "../config/routes";
 
@@ -27,7 +34,7 @@ const NotEligible: React.FC = () => {
         <Title variant="h2">Oops!</Title>
       </Grid>
       <Grid item xs={12}>
-        <Message>You are not eligible for this Airdrop!</Message>
+        <Message>You are not eligible for this airdrop.</Message>
       </Grid>
       <Grid item xs={12}>
         <Button
@@ -42,6 +49,80 @@ const NotEligible: React.FC = () => {
   );
 };
 
+const Eligible: React.FC = () => {
+  return (
+    <CenterGrid container spacing={3}>
+      <Grid item xs={12}>
+        <Title variant="h2">Congratulations Homie!</Title>
+      </Grid>
+      <Grid item xs={12}>
+        <Message>You are eligible for this airdrop.</Message>
+      </Grid>
+      <Grid item xs={12}>
+        <Button onClick={() => console.log}>Continue to Airdrop</Button>
+      </Grid>
+    </CenterGrid>
+  );
+};
+
+interface TokenClaimedProps {
+  amountClaimed: number;
+  symbol: string;
+}
+
+const TokenClaimed: React.FC<TokenClaimedProps> = ({
+  amountClaimed,
+  symbol,
+}) => {
+  const history = useHistory();
+  return (
+    <CenterGrid container spacing={3}>
+      <Grid item xs={12}>
+        <Message>
+          Your token of {amountClaimed} {symbol} has been claimed successfully
+          and added to your wallet for being a member of the Homies community.
+          Use your influence with wisdom.
+        </Message>
+      </Grid>
+      <Grid item xs={12}>
+        <Button
+          onClick={() => {
+            history.push(AppRoute.Home);
+          }}
+        >
+          Go Home
+        </Button>
+      </Grid>
+    </CenterGrid>
+  );
+};
+
+enum ClaimPageState {
+  LoadingState,
+  NotEligibleState,
+  EligibleState,
+  TokenClaimedState,
+}
+
 export const ClaimPage: React.FC = () => {
-  return <NotEligible />;
+  const [currentState, setCurrentState] = useState<ClaimPageState>(
+    ClaimPageState.TokenClaimedState
+  );
+
+  switch (currentState) {
+    case ClaimPageState.LoadingState:
+      return (
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <CircularProgress />
+        </Box>
+      );
+    case ClaimPageState.NotEligibleState:
+      return <NotEligible />;
+    case ClaimPageState.EligibleState:
+      return <Eligible />;
+    case ClaimPageState.TokenClaimedState:
+      return <TokenClaimed amountClaimed={5000} symbol="HOMIE" />;
+    default:
+      return <>Unknown State 😜</>;
+  }
 };

--- a/modules/web-dapp/src/page/ClaimPage.tsx
+++ b/modules/web-dapp/src/page/ClaimPage.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import { AppRoute } from "../config/routes";
 import { ClaimPageState, useClaimPage } from "../hooks/useClaimPage";
+import { tokenValue } from "../helpers/formatters";
 
 // CenterGrid is a styled mui Grid that centers aligns its
 // children center. Useful in this page components.
@@ -100,7 +101,8 @@ const TokenClaimed: React.FC<TokenClaimedProps> = ({
 };
 
 export const ClaimPage: React.FC = () => {
-  const { currentState } = useClaimPage();
+  const { currentState, amountToBeClaimed, tokenSymbol, tokenDecimals } =
+    useClaimPage();
 
   switch (currentState) {
     case ClaimPageState.LoadingState:
@@ -114,7 +116,12 @@ export const ClaimPage: React.FC = () => {
     case ClaimPageState.EligibleState:
       return <Eligible />;
     case ClaimPageState.TokenClaimedState:
-      return <TokenClaimed amountClaimed={5000} symbol="HOMIE" />;
+      return (
+        <TokenClaimed
+          amountClaimed={tokenValue(amountToBeClaimed, tokenDecimals)}
+          symbol={tokenSymbol}
+        />
+      );
     default:
       return <>Unknown State 😜</>;
   }

--- a/modules/web-dapp/src/page/ClaimPage.tsx
+++ b/modules/web-dapp/src/page/ClaimPage.tsx
@@ -6,9 +6,10 @@ import {
   styled,
   Typography,
 } from "@mui/material";
-import React, { useState } from "react";
+import React from "react";
 import { useHistory } from "react-router-dom";
 import { AppRoute } from "../config/routes";
+import { ClaimPageState, useClaimPage } from "../hooks/useClaimPage";
 
 // CenterGrid is a styled mui Grid that centers aligns its
 // children center. Useful in this page components.
@@ -59,6 +60,7 @@ const Eligible: React.FC = () => {
         <Message>You are eligible for this airdrop.</Message>
       </Grid>
       <Grid item xs={12}>
+        {/* eslint-disable-next-line no-console */}
         <Button onClick={() => console.log}>Continue to Airdrop</Button>
       </Grid>
     </CenterGrid>
@@ -97,17 +99,8 @@ const TokenClaimed: React.FC<TokenClaimedProps> = ({
   );
 };
 
-enum ClaimPageState {
-  LoadingState,
-  NotEligibleState,
-  EligibleState,
-  TokenClaimedState,
-}
-
 export const ClaimPage: React.FC = () => {
-  const [currentState, setCurrentState] = useState<ClaimPageState>(
-    ClaimPageState.TokenClaimedState
-  );
+  const { currentState } = useClaimPage();
 
   switch (currentState) {
     case ClaimPageState.LoadingState:


### PR DESCRIPTION
This setup the various state views users can be when interacting with the contract. All state information is fetched from the Airdrop Contract.

**Not Eligble**
<img width="638" alt="Screenshot 2022-03-07 at 9 10 33 pm" src="https://user-images.githubusercontent.com/3120013/157118347-fab047b5-41e1-4036-aa34-299af7a8bfc7.png">

**Eligible**
<img width="597" alt="Screenshot 2022-03-07 at 9 11 23 pm" src="https://user-images.githubusercontent.com/3120013/157118457-4eba8552-4f7d-4382-bc03-05969fe707bd.png">

**Already Claimed**
<img width="560" alt="Screenshot 2022-03-07 at 9 12 00 pm" src="https://user-images.githubusercontent.com/3120013/157118614-812601a4-db4f-429d-8829-b7a986683269.png">


This resolves #8, resolves #9