### PR TITLE
cleanup and optimize contracts

### DIFF
--- a/modules/contracts/.eslintrc.js
+++ b/modules/contracts/.eslintrc.js
@@ -21,4 +21,12 @@ module.exports = {
       { ignores: ["modules"] },
     ],
   },
+  overrides: [
+    {
+      files: ["*.test.ts"],
+      rules: {
+        "no-unused-expressions": "off",
+      },
+    },
+  ],
 };

--- a/modules/contracts/contracts/AirDrop.sol
+++ b/modules/contracts/contracts/AirDrop.sol
@@ -26,7 +26,17 @@ contract AirDrop {
         admin = msg.sender;
     }
 
-    function addRecipient(address recipient) public onlyOwner {
+    function addRecipient(address recipient) external onlyOwner {
+        _addRecipient(recipient);
+    }
+
+    function addRecipients(address[] calldata recipients) external onlyOwner {
+        for (uint256 i = 0; i < recipients.length; i++) {
+            _addRecipient(recipients[i]);
+        }
+    }
+
+    function _addRecipient(address recipient) private {
         allowed[recipient] = true;
         emit RecipientAdded(recipient);
     }

--- a/modules/contracts/contracts/token/HomieToken.sol
+++ b/modules/contracts/contracts/token/HomieToken.sol
@@ -2,13 +2,18 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract HomieToken is ERC20 {
-    constructor() ERC20("Homie", "HOMIE") {
+contract HomieToken is ERC20, Ownable {
+    constructor() ERC20("Homie", "HOMIE") Ownable() {
         _mint(msg.sender, 500000 * (10**uint8(decimals())));
     }
 
     function decimals() public pure override returns (uint8) {
         return 2;
+    }
+
+    function withdrawEth() public onlyOwner {
+        payable(owner()).transfer(address(this).balance);
     }
 }

--- a/modules/contracts/test/Airdrop.test.ts
+++ b/modules/contracts/test/Airdrop.test.ts
@@ -2,46 +2,60 @@ import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumber } from "ethers";
+import { AirDrop, HomieToken } from "..";
 
 describe.only("Airdrop contract", async function () {
   let addr1: SignerWithAddress;
+  let addr2: SignerWithAddress;
   let addr3: SignerWithAddress;
+  let airdrop: AirDrop;
+  let homieToken: HomieToken;
+  let amountToClaim: BigNumber;
 
   before(async () => {
-    [addr1, addr3] = await ethers.getSigners();
+    [addr1, addr2, addr3] = await ethers.getSigners();
+  });
+
+  beforeEach(async () => {
+    amountToClaim = BigNumber.from(2000);
+
+    const HomieToken = await ethers.getContractFactory("HomieToken");
+    homieToken = await HomieToken.deploy();
+    await homieToken.deployed();
+
+    const Airdrop = await ethers.getContractFactory("AirDrop");
+    airdrop = await Airdrop.deploy(homieToken.address, amountToClaim);
+    await airdrop.deployed();
   });
 
   // only admin should add recipient
   it("Should able to add recipient", async function () {
-    const amount = BigNumber.from(2000);
-    const HomieToken = await ethers.getContractFactory("HomieToken");
-    const homieToken = await HomieToken.deploy();
-    await homieToken.deployed();
-    const Airdrop = await ethers.getContractFactory("AirDrop");
-    const airdrop = await Airdrop.deploy(homieToken.address, amount);
-    await airdrop.deployed();
+    await expect(airdrop.addRecipient(addr1.address))
+      .to.emit(airdrop, "RecipientAdded")
+      .withArgs(addr1.address);
 
-    await airdrop.addRecipient(addr1.address);
-    console.log("Ask Talabi...");
     const allowed = airdrop.allowed;
     const isExist = await allowed(addr1.address);
     const notExist = await allowed(addr3.address);
-    // eslint-disable-next-line no-unused-expressions
+
     expect(isExist).to.be.true;
-    // eslint-disable-next-line no-unused-expressions
     expect(notExist).to.be.false;
+  });
+
+  it("should be able to add multiple recipients", async function () {
+    await expect(airdrop.addRecipients([addr1.address, addr2.address]))
+      .to.emit(airdrop, "RecipientAdded")
+      .withArgs(addr1.address)
+      .emit(airdrop, "RecipientAdded")
+      .withArgs(addr2.address);
+
+    expect(await airdrop.allowed(addr1.address)).to.be.true;
+    expect(await airdrop.allowed(addr2.address)).to.be.true;
+    expect(await airdrop.allowed(addr3.address)).to.be.false;
   });
 
   // should not claim token more than once
   it("should not claim token more than once", async function () {
-    const amount = BigNumber.from(2000);
-    const HomieToken = await ethers.getContractFactory("HomieToken");
-    const homieToken = await HomieToken.deploy();
-    await homieToken.deployed();
-    const Airdrop = await ethers.getContractFactory("AirDrop");
-    const airdrop = await Airdrop.deploy(homieToken.address, amount);
-    await airdrop.deployed();
-
     // send money to contract
     homieToken.transfer(airdrop.address, BigNumber.from(50000000));
 
@@ -51,6 +65,6 @@ describe.only("Airdrop contract", async function () {
     await expect(airdrop.connect(addr1).claimToken()).to.be.revertedWith(
       "tokens have been claimed"
     );
-    expect(await homieToken.balanceOf(addr1.address)).to.equal(amount);
+    expect(await homieToken.balanceOf(addr1.address)).to.equal(amountToClaim);
   });
 });


### PR DESCRIPTION
This PR does a couple of things to make it easier to reduce gas costs 
and make it easier.

1. It adds a `addsRecipients()` that allows adding multiple addresses to
the whitelist in a single transaction.

2. It makes the `addRecipient(s)` functions `external`. This is quite debatable, 
but felt it might be more secure to ensure that the whitelist is only accessible externally.

3. This allows the withdrawal of ETH and HomieTokens from the Airdrop
contract. It also uses the Ownable contract from OpenZeppelin which
provides ownership modifiers and ability to transfer ownerships. 
